### PR TITLE
fix(blog): Use wordpress feed url

### DIFF
--- a/venus/planet/planet.ini
+++ b/venus/planet/planet.ini
@@ -73,5 +73,5 @@ name = Rohan VB
 [https://techievena.github.io/feed.xml]
 name = Abinash Senapati
 
-[https://niklas-meinzer.de/tag/coala/]
+[https://niklas-meinzer.de/tag/coala/feed]
 name = Niklas Meinzer


### PR DESCRIPTION
@yukiisbored my post wasn't added, probably because I need to point to some sort of feed, instead of the UI. I changed the link to point to an RSS feed. Does this look right now?