### PR TITLE
Fix overflowing header

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,8 @@
     <main>
       <div class="container mp">
         <div class="row">
-          <div class="col s6"></div>
-          <div class="col s6">
             <div class="title">coala</div>
             <div class="devops-subtitle"><span class="dev-text">dev</span><span class="ops-text">ops</span></div>
-          </div>
         </div>
       </div>
       <div class="section">

--- a/style.css
+++ b/style.css
@@ -1,10 +1,15 @@
 /* Custom CSS for Devops Heading */
 
+
+.title {
+  font-size: 8em;
+}
+
 .devops-subtitle {
   text-transform: uppercase;
   letter-spacing: 1.5em;
   text-align: center;
-  font-size: 2em;
+  font-size: 1.5em;
   font-weight: 500;
   text-indent: 1.8em;
   text-align: 1em;
@@ -18,4 +23,14 @@
 
 .ops-text {
   color: darkslategrey;
+}
+
+@media(min-width: 1200px) {
+  .title {
+    font-size: 14em;
+  }
+
+  .devops-subtitle {
+    font-size: 2em;
+  }
 }


### PR DESCRIPTION
Fixes issue #75.

Same changes as before, but I corrected the commit and split it into two atomic changes. 👍 

## Changes

- Remove s6 columns that were splitting the header in half
- Set font-sizes smaller in CSS, then media query for Desktop sizes