### PR TITLE
Short-URL for cEPs added

### DIFF
--- a/nginx/nginx.conf.d/coala.io.conf
+++ b/nginx/nginx.conf.d/coala.io.conf
@@ -25,6 +25,16 @@ server {
     location /rebase    { return 302 https://coala.io/git#rebasing; }
     location /commit    { return 302 http://api.coala.io/en/latest/Developers/Writing_Good_Commits.html; }
     location /cep       { return 302 https://github.com/coala/cEPs/blob/master/cEP-0000.md; }
+    location /cep1      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0001.md; }
+    location /cep2      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0002.md; }
+    location /cep3      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0003.md; }
+    location /cep5      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0005.md; }
+    location /cep6      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0006.md; }
+    location /cep9      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0009.md; }
+    location /cep10     { return 302 https://github.com/coala/cEPs/blob/master/cEP-0010.md; }
+    location /cep12     { return 302 https://github.com/coala/cEPs/blob/master/cEP-0012.md; }
+    location /cep13     { return 302 https://github.com/coala/cEPs/blob/master/cEP-0013.md; }
+    location /cep14     { return 302 https://github.com/coala/cEPs/blob/master/cEP-0014.md; }
     location /coc       { return 302 https://github.com/coala/cEPs/blob/master/cEP-0006.md; }
     location /tutorial  { return 302 https://docs.coala.io/en/latest/Users/Tutorial.html; }
     location /writingbears { return 302 https://api.coala.io/en/latest/Developers/Writing_Native_Bears.html; }
@@ -35,7 +45,6 @@ server {
     location /reply     { return 302 https://github.com/coala/coala/wiki/Reply-Templates; }
     location /linespots { return 302 https://gitlab.com/sims1253/Linespots; }
     location /usability { return 302 https://docs.google.com/forms/d/e/1FAIpQLSe9lZxuYEKlvxXzQUOTwrre3CQMNsks7eOzEl49_2q5vlDl0w/viewform; }
-    location /cep5      { return 302 https://github.com/coala/cEPs/blob/master/cEP-0005.md; }
     location /starwars  { return 302 https://www.youtube.com/watch?v=JWVCMjKU_10; }
     location /docs      { return 302 https://docs.coala.io/; }
     location /api       { return 302 https://api.coala.io/; }


### PR DESCRIPTION
Short-URL for cEPs added.


Closes https://github.com/coala/devops/issues/85