### PR TITLE
coala.io.conf: Fix link to bears doc page

### DIFF
--- a/nginx/nginx.conf.d/coala.io.conf
+++ b/nginx/nginx.conf.d/coala.io.conf
@@ -19,7 +19,7 @@ server {
     location /greview   { return 302 https://gitlab.com/groups/coala/merge_requests; }
     location /approved  { return 302 https://github.com/pulls?q=is%3Aopen+user%3Acoala+label%3A%22process%2Fapproved%22+sort%3Acreated-asc; }
     location /reviewing { return 302 http://api.coala.io/en/latest/Developers/Review.html; }
-    location /languages { return 302 http://coala.io/#!/languages; }
+    location /languages { return 302 http://coala.io/#/languages; }
     location /chat      { return 302 https://gitter.im/coala-analyzer/coala; }
     location /git       { return 302 http://api.coala.io/en/latest/Developers/Git_Basics.html; }
     location /rebase    { return 302 https://coala.io/git#rebasing; }


### PR DESCRIPTION
This fixes the link to bears documentation and
corrects it from ``https://coala.io/#!/languages``
to ``https://coala.io/#/languages``.

Closes https://github.com/coala/devops/issues/93